### PR TITLE
Updates README with an example for Google Auth and uses id_token for validation since access_token need not be a valid JWT according to spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ oauth_params = {'authorization_enddpoint': ...} # Or any way to create the dicti
 id = st_oauth(oauth_params)
 ```
 
+A sample configuration with Google OAuth looks like this
+
+```
+[oauth]
+authorization_endpoint = "https://accounts.google.com/o/oauth2/auth"
+token_endpoint = "https://oauth2.googleapis.com/token"
+jwks_uri = "https://www.googleapis.com/oauth2/v3/certs"
+redirect_uri = "http://localhost:8501"
+client_id = "<GOOGLE_PROJECT_CLIENT_ID>"
+client_secret = "<GOOGLE_PROJECT_CLIENT_SECRET>"
+scope = "email profile"
+audience = "<GOOGLE_PROJECT_CLIENT_ID>"
+identity_field_in_token = "sub"
+```
+
 ### Multipage Streamlit Apps
 This component supports multipage Streamlit apps. Just include
 the call to `snowauth_session()` at the top of every page. If 
@@ -114,3 +129,4 @@ you can test it yourself directly:
 if st_oauth._STKEY in st.session_state:
     do_something()
 ```
+

--- a/st_oauth/st_oauth.py
+++ b/st_oauth/st_oauth.py
@@ -46,9 +46,9 @@ def show_auth_link(config, label):
     st.stop()
     
 def validate_token(token, config):
-    signing_key = jwks_client(config['jwks_uri']).get_signing_key_from_jwt(token['access_token'])
+    signing_key = jwks_client(config['jwks_uri']).get_signing_key_from_jwt(token['id_token'])
     try:
-        data = jwt.decode(token['access_token'], signing_key.key, algorithms=["RS256"], audience=config['audience'] if 'audience' in config else None)
+        data = jwt.decode(token['id_token'], signing_key.key, algorithms=["RS256"], audience=config['audience'] if 'audience' in config else None)
     except (jwt.exceptions.ExpiredSignatureError):
         return False, 'Expired'
     except:

--- a/st_oauth/st_oauth.py
+++ b/st_oauth/st_oauth.py
@@ -39,9 +39,9 @@ def show_auth_link(config, label):
     state_parameter = string_num_generator(15)
     query_params = urlencode({'redirect_uri': config['redirect_uri'], 'client_id': config['client_id'], 'response_type': 'code', 'state': state_parameter, 'scope': config['scope']})
     request_url = f"{config['authorization_endpoint']}?{query_params}"
-    if st.experimental_get_query_params():
+    if st.query_params:
         qpcache = qparms_cache(state_parameter)
-        qpcache = st.experimental_get_query_params()
+        qpcache = st.query_params
     st.markdown(f'<a href="{request_url}" target="_self">{label}</a>', unsafe_allow_html=True)
     st.stop()
     
@@ -70,14 +70,14 @@ def st_oauth(config=None, label="Login via OAuth"):
         if not validate_config(config):
             st.error("Invalid OAuth Configuration")
             st.stop()
-        if 'code' not in st.experimental_get_query_params():
+        if 'code' not in st.query_params:
             show_auth_link(config, label)
-        code = st.experimental_get_query_params()['code'][0]
-        state = st.experimental_get_query_params()['state'][0]
+        code = st.query_params['code']
+        state = st.query_params['state']
         qpcache = qparms_cache(state)
         qparms = qpcache
         qpcache = {}
-        st.experimental_set_query_params(**qparms)
+        st.query_params.from_dict(qparms)
         theaders = {
                         'Content-type': 'application/x-www-form-urlencoded;charset=utf-8'
                     }


### PR DESCRIPTION
Have created pull request since while trying with Google Oauth we were getting **DecodeError: Not enough segments** exception.
Updated Readme with an example for people to use it for Google Oauth in the future.