### PR TITLE
Fixing JWT dependency and fixing authentication flow for Google OAuth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     author='Brian Hess',
     author_email='brian.hess@snowflake.com',
     license='LICENSE.txt',
-    install_requires=['streamlit', 'requests', 'jwt']
+    install_requires=['streamlit', 'requests', 'pyjwt']
 )

--- a/st_oauth/st_oauth.py
+++ b/st_oauth/st_oauth.py
@@ -46,9 +46,9 @@ def show_auth_link(config, label):
     st.stop()
     
 def validate_token(token, config):
-    signing_key = jwks_client(config['jwks_uri']).get_signing_key_from_jwt(token['access_token'])
+    signing_key = jwks_client(config['jwks_uri']).get_signing_key_from_jwt(token['id_token'])
     try:
-        data = jwt.decode(token['access_token'], signing_key.key, algorithms=["RS256"], audience=config['audience'] if 'audience' in config else None)
+        data = jwt.decode(token['id_token'], signing_key.key, algorithms=["RS256"], audience=config['audience'] if 'audience' in config else None)
     except (jwt.exceptions.ExpiredSignatureError):
         return False, 'Expired'
     except:


### PR DESCRIPTION
Hi,

Here is a small PR to address the current JWT dependency issue when using jwt directly instead of pyjwt.
There is also a fix in order for this code to work with Google OAuth (and use id_token instead of access_token which is empty in Google's authentication flow)